### PR TITLE
Add PHP-8.1 and PHP-8.2 tests in GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
@@ -34,13 +34,8 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Install dependencies for PHP 7
-        if: matrix.php-versions < '8.0'
+      - name: Install dependencies for PHP
         run: composer update --prefer-dist --no-progress
-
-      - name: Install dependencies for PHP 8
-        if: matrix.php-versions >= '8.0'
-        run: composer update --prefer-dist --no-progress --ignore-platform-req=php
 
       - name: Run test suite
         run: composer check

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,4 @@ parameters:
 		- src
 		- tests
 	ignoreErrors:
-		- '#Cannot cast mixed to string.#'
 		- '#Parameter \#2 ...\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given.#'

--- a/src/SameSiteCookieMiddleware.php
+++ b/src/SameSiteCookieMiddleware.php
@@ -6,7 +6,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 
 /**
  * SameSite Cookie Middleware.
@@ -43,7 +42,7 @@ final class SameSiteCookieMiddleware implements MiddlewareInterface
      * @param ServerRequestInterface $request The request
      * @param RequestHandlerInterface $handler The handler
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ResponseInterface The response
      */
@@ -56,7 +55,7 @@ final class SameSiteCookieMiddleware implements MiddlewareInterface
         $params = $this->sessionHandler->getCookieParams();
 
         if (!$sessionId || !$sessionName || !$params) {
-            throw new RuntimeException('The session must be started before samesite cookie can be generated.');
+            throw new \RuntimeException('The session must be started before samesite cookie can be generated.');
         }
 
         $cookieValues = [


### PR DESCRIPTION
# Changed log

- Add `PHP-8.1` and `PHP-8.2` tests in the GitHub workflow action.
- Apply coding style fix via the PHP-CS-Fixer.
- Remove the ignored `'#Cannot cast mixed to string.#'` error setting to avoid following error message:

```
$ php ~/composer.phar phpstan
> phpstan analyse -c phpstan.neon --no-progress --ansi
 -- ------------------------------------------------------------------------------------------
     Error
 -- ------------------------------------------------------------------------------------------
     Ignored error pattern #Cannot cast mixed to string.# was not matched in reported errors.
 -- ------------------------------------------------------------------------------------------



 [ERROR] Found 1 error
```